### PR TITLE
Add diagonal PT and PT presets

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -2,7 +2,7 @@ exports.getActions = function () {
 
 	let actions = {}
 
-	actions['joyStickOperationPT'] = {
+	actions['joyStickOperationPan'] = {
 		label: 'Pan camera',
 		options: [
 			{

--- a/actions.js
+++ b/actions.js
@@ -2,7 +2,7 @@ exports.getActions = function () {
 
 	let actions = {}
 
-	actions['joyStickOperationPan'] = {
+	actions['joyStickOperationPT'] = {
 		label: 'Pan camera',
 		options: [
 			{
@@ -10,7 +10,7 @@ exports.getActions = function () {
 				type: 'dropdown',
 				id: 'direction',
 				default: 'Stop',
-				choices: [{ label: 'Left', id: 'Left' }, { label: 'Right', id: 'Right' }, { label: 'Stop', id: 'Stop' }]
+				choices: [{ label: 'Left', id: 'Left' }, { label: 'Right', id: 'Right' }, { label: 'RightUp', id: 'RightUp' } , { label: 'RightDown', id: 'RightDown' }, { label: 'LeftUp', id: 'LeftUp' }, { label: 'LeftDown', id: 'LeftDown' }, { label: 'Up', id: 'Up' } , { label: 'Down', id: 'Down' }, { label: 'Stop', id: 'Stop' }]
 			},
 			{
 				label: 'Select speed (0-100)',
@@ -199,6 +199,18 @@ exports.getActions = function () {
 				id: 'ctrl',
 				default: 'Rec',
 				choices: [{ label: 'Record', id: 'Rec' }, { label: 'Stop recording', id: 'Stop' }]
+			}
+		]
+	}
+	actions['setCamCtrl'] = {
+		label: 'Streaming control',
+		options: [
+			{
+				label: 'Select value',
+				type: 'dropdown',
+				id: 'ctrl',
+				default: 'Stream',
+				choices: [{ label: 'Start Stream', id: 'Stream' }, { label: 'Stop Stream', id: 'Stop' }]
 			}
 		]
 	}

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -30,6 +30,33 @@ module.exports = {
 				}
 			}
 		};
+		feedbacks['streaming'] = {
+			label: 'Change background when streaming',
+			description: 'When camera is streaming, background color will change',
+			options: [
+				{
+					type: 'colorpicker',
+					label: 'Foreground color',
+					id: 'fg',
+					default: this.rgb(255, 255, 255)
+
+				},
+				{
+					type: 'colorpicker',
+					label: 'Background color',
+					id: 'bg',
+					default: this.rgb(255, 0, 0)
+				}
+			],
+			callback: (feedback, bank) => {
+				if (this.streaming == 1) {
+					return {
+						color: feedback.options.fg,
+						bgcolor: feedback.options.bg
+					};
+				}
+			}
+		};
 
 		feedbacks['tally_PGM'] = {
 			label: 'Tally on PGM',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jvc-ptz",
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Camera",

--- a/presets.js
+++ b/presets.js
@@ -4,6 +4,258 @@ exports.getPresets = function () {
 	// Stealth Toggle
 	presets.push({
 		category: 'Pan/Tilt',
+		label: 'UP',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_UP,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Up',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+	presets.push({
+		category: 'Pan/Tilt',
+		label: 'DOWN',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_DOWN,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Down',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+	presets.push({
+		category: 'Pan/Tilt',
+		label: 'RIGHT',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_RIGHT,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Right',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+	presets.push({
+		category: 'Pan/Tilt',
+		label: 'LEFT',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_LEFT,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Left',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+	presets.push({
+		category: 'Pan/Tilt',
+		label: 'RIGHTUP',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_UP_RIGHT,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'RightUp',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+	presets.push({
+		category: 'Pan/Tilt',
+		label: 'RIGHTDOWN',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_DOWN_RIGHT,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'RightDown',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+	presets.push({
+		category: 'Pan/Tilt',
+		label: 'LEFTUP',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_UP_LEFT,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'LeftUp',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+	presets.push({
+		category: 'Pan/Tilt',
+		label: 'LEFTDOWN',
+		bank: {
+			style: 'png',
+			text: '',
+			png64: this.ICON_DOWN_LEFT,
+			pngalignment: 'center:center',
+			size: '18',
+			color: '16777215',
+			bgcolor: this.rgb(0, 0, 0)
+		},
+		actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'LeftDown',
+					speed: '15'
+				}
+			}
+		],
+		release_actions: [
+			{
+				action: 'joyStickOperationPT',
+				options: {
+					direction: 'Stop',
+					speed: '0'
+				}
+			}
+		]
+	});
+
+
+
+
+	presets.push({
+		category: 'Pan/Tilt',
 		label: 'Pan left',
 		bank: {
 			style: 'text',

--- a/presets.js
+++ b/presets.js
@@ -16,7 +16,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Up',
 					speed: '15'
@@ -25,7 +25,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -47,7 +47,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Down',
 					speed: '15'
@@ -56,7 +56,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -78,7 +78,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Right',
 					speed: '15'
@@ -87,7 +87,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -109,7 +109,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Left',
 					speed: '15'
@@ -118,7 +118,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -140,7 +140,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'RightUp',
 					speed: '15'
@@ -149,7 +149,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -171,7 +171,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'RightDown',
 					speed: '15'
@@ -180,7 +180,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -202,7 +202,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'LeftUp',
 					speed: '15'
@@ -211,7 +211,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -233,7 +233,7 @@ exports.getPresets = function () {
 		},
 		actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'LeftDown',
 					speed: '15'
@@ -242,7 +242,7 @@ exports.getPresets = function () {
 		],
 		release_actions: [
 			{
-				action: 'joyStickOperationPT',
+				action: 'joyStickOperationPan',
 				options: {
 					direction: 'Stop',
 					speed: '0'
@@ -316,7 +316,7 @@ exports.getPresets = function () {
 
 	presets.push({
 		category: 'Pan/Tilt',
-		label: 'Tit up',
+		label: 'Tilt up',
 		bank: {
 			style: 'text',
 			text: 'Tilt up, speed 15',
@@ -346,7 +346,7 @@ exports.getPresets = function () {
 
 	presets.push({
 		category: 'Pan/Tilt',
-		label: 'Tit Down',
+		label: 'Tilt Down',
 		bank: {
 			style: 'text',
 			text: 'Tilt down, speed 15',


### PR DESCRIPTION
Added PT-commands for diagonal moves.
Added PT-presets, including icons

Added extra buttons according to the documentation of JVC. Only shift and tilt were implemented, this pull adds diagonal moves.
Added extra buttons to control streaming on/of of the camera, next to the control of recording.
Added feedback about streaming status